### PR TITLE
Documentation variable names typos, around `ebdb-accept-header-alist'

### DIFF
--- a/ebdb-mua.el
+++ b/ebdb-mua.el
@@ -178,7 +178,7 @@ also consider the email addresses in the remaining headers."
 The format of this alist is
    ((HEADER-TYPE . REGEXP) ...)
 
-Where HEADER-TYPE is one of the symbols 'sender, 'recipients',
+Where HEADER-TYPE is one of the symbols 'sender, 'recipients,
 'any (meaning 'sender or 'recipients), or 'subject.
 
 For example, if
@@ -186,14 +186,14 @@ For example, if
     (subject . \"time travel\"))
 EBDB records are only created for messages sent by people at Maximegalon U.,
 or people posting about time travel.
-If t accept all messages.  If nil, accept all messages.
+If t accept all messages.  If nil, does not accept any message.
 
 See also `ebdb-ignore-header-alist', which has the opposite effect."
   :type '(repeat (cons
                   (choice (symbol :tag "Sender" sender)
-			  (symbol :tag "Recipients" recipients)
-			  (symbol :tag "Sender or recipients" any)
-			  (symbol :tag "Subject" subject))
+			              (symbol :tag "Recipients" recipients)
+			              (symbol :tag "Sender or recipients" any)
+			              (symbol :tag "Subject" subject))
                   (regexp :tag "Regexp to match on header value"))))
 
 (defcustom ebdb-ignore-header-alist nil

--- a/ebdb-mua.el
+++ b/ebdb-mua.el
@@ -191,9 +191,9 @@ If t accept all messages.  If nil, does not accept any message.
 See also `ebdb-ignore-header-alist', which has the opposite effect."
   :type '(repeat (cons
                   (choice (symbol :tag "Sender" sender)
-			              (symbol :tag "Recipients" recipients)
-			              (symbol :tag "Sender or recipients" any)
-			              (symbol :tag "Subject" subject))
+			  (symbol :tag "Recipients" recipients)
+			  (symbol :tag "Sender or recipients" any)
+			  (symbol :tag "Subject" subject))
                   (regexp :tag "Regexp to match on header value"))))
 
 (defcustom ebdb-ignore-header-alist nil

--- a/ebdb.info
+++ b/ebdb.info
@@ -805,15 +805,15 @@ more options come into play:
    There are also options governing whether EBDB will consider a mail
 address or not:
 
- -- User Option: ebdb-accept-header-list
+ -- User Option: ebdb-accept-header-alist
      An alist governing which addresses in which headers will be
      accepted.  See docstring for details.
 
- -- User Option: ebdb-ignore-header-list
+ -- User Option: ebdb-ignore-header-alist
      An alist governing which addresses in which headers will be
      ignored.  See docstring for details.
 
- -- User Option: ebdb-user-name-address-re
+ -- User Option: ebdb-user-mail-address-re
      A regular expression matching the user’s own mail address(es).  In
      addition to a regexp, this can also be the symbol ‘message’, in
      which case the value will be copied from


### PR DESCRIPTION
Hi, may be there are some misspelled sentences in documentation.

Thanks for your project